### PR TITLE
Add Django and Jinja2 template support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.8"
 dependencies = []
 
 [project.optional-dependencies]
-django = []
+django = ["Django>=3.2"]
 jinja = ["Jinja2>=3.0"]
 dev = ["pytest", "pytest-cov", "black", "flake8", "mypy"]
 

--- a/src/korean_glue/integrations/__init__.py
+++ b/src/korean_glue/integrations/__init__.py
@@ -1,1 +1,5 @@
 """Integration helpers for web frameworks."""
+
+from . import django_tags, jinja_filters
+
+__all__ = ["django_tags", "jinja_filters"]

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,41 @@
+import pytest
+
+from korean_glue.integrations import jinja_filters, django_tags
+from jinja2 import Environment
+from django.template import Engine, Context
+from django.conf import settings
+import django
+
+if not settings.configured:
+    settings.configure(TEMPLATES=[{"BACKEND": "django.template.backends.django.DjangoTemplates"}])
+django.setup()
+
+
+def test_jinja_filter_basic():
+    env = Environment()
+    jinja_filters.register(env)
+    template = env.from_string("{{ word|josa('으로/로') }}")
+    result = template.render(word="서울")
+    assert result == "서울로"
+
+
+def test_jinja_filter_non_string():
+    env = Environment()
+    jinja_filters.register(env)
+    template = env.from_string("{{ value|josa('을/를') }}")
+    result = template.render(value=10)
+    assert result == "10"
+
+
+def test_django_filter_basic():
+    engine = Engine(builtins=["korean_glue.integrations.django_tags"])
+    template = engine.from_string("{{ word|josa:'이/가' }}")
+    result = template.render(Context({"word": "사과"}))
+    assert result == "사과가"
+
+
+def test_django_filter_non_string():
+    engine = Engine(builtins=["korean_glue.integrations.django_tags"])
+    template = engine.from_string("{{ value|josa:'을/를' }}")
+    result = template.render(Context({"value": 10}))
+    assert result == "10"


### PR DESCRIPTION
## Summary
- expose Django and Jinja2 integrations
- declare Django optional dependency
- add Django and Jinja2 integration tests

## Testing
- `pip install -e .[dev,django,jinja]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847692518dc8326aa65e2f5c5c320b5