### PR TITLE
Add unified checks and pre-commit setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Guidance for Codex Agents
+
+This document provides guidelines for making changes to this open source Python package. Please follow them carefully.
+
+## Prerequisites
+
+- Python 3.10 or newer
+- [`uv`](https://github.com/astral-sh/uv)
+- [`pre-commit`](https://pre-commit.com/)
+
+## Development Setup
+
+1. **Create and activate the virtual environment:**
+   ```bash
+   uv venv
+   source .venv/bin/activate    # On Windows use: .venv\Scripts\activate
+   ```
+2. **Install dependencies:**
+   ```bash
+   uv pip install -e ".[dev]"
+   ```
+3. **Set up pre-commit hooks:**
+   ```bash
+   pre-commit install
+   ```
+
+## Quality Checks & Workflow
+
+Run all checks with the helper script:
+
+```bash
+bash scripts/check.sh
+```
+
+The script runs formatting and linting via `pre-commit`, then type checks with `mypy` and runs the test suite with `pytest`.
+
+You can also invoke pre-commit manually:
+```bash
+pre-commit run --all-files
+```
+
+## Pull Requests
+
+- Summarize user-facing changes.
+- CI/CD 자동화 검사가 통과해야 합니다. 로컬에서는 `bash scripts/check.sh`로 확인할 수 있습니다.
+- Ensure all checks pass before submitting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = []
 [project.optional-dependencies]
 django = []
 jinja = ["Jinja2>=3.0"]
-dev = ["pytest", "pytest-cov", "black", "flake8", "mypy"]
+dev = ["pytest", "pytest-cov", "black", "flake8", "mypy", "pre-commit"]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run formatting and linting via pre-commit
+pre-commit run --all-files
+
+# Type checking
+uv run mypy --ignore-missing-imports src
+
+# Run tests
+uv run pytest

--- a/src/korean_glue/rules.py
+++ b/src/korean_glue/rules.py
@@ -22,7 +22,7 @@ _FINAL_ALPHABET = set("FHLMNRS")
 
 
 def has_final_consonant(word: str) -> bool:
-    """Return True if ``word`` should be treated as ending with a final consonant."""
+    """Return True if ``word`` ends with a final consonant."""
     if not word:
         return False
     last = word[-1]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -43,4 +43,3 @@ def test_exception_rule():
         assert attach("사과", "은/는") == "사과딱"
     finally:
         remove_exception_rule("사과", "은/는")
-


### PR DESCRIPTION
## Summary
- update AGENT instructions with a single `scripts/check.sh` entrypoint and CI/CD note
- add `.pre-commit-config.yaml`
- add helper script to run formatting, linting, type checking, and tests
- ignore `uv.lock`
- include pre-commit in dev dependencies

## Testing
- `pre-commit run --all-files`
- `bash scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_b_68476975a9748326b8aea216a1d86508