### PR TITLE
Add command line interface

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -34,6 +34,16 @@ print(attach("사과", "은/는"))  # "사과당"
 remove_exception_rule("사과", "은/는")
 ```
 
+### CLI 사용 예
+
+패키지를 설치한 뒤 `kglue` 명령어로 간단히 확인할 수 있습니다.
+
+```bash
+kglue '철수(은/는)'
+kglue 'K(이/가)'
+kglue '3(을/를)'
+```
+
 ### 프레임워크 연동
 
 **Django**

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ print(attach("사과", "은/는"))  # "사과당"
 remove_exception_rule("사과", "은/는")
 ```
 
+### Command Line
+
+Install the package and run the `kglue` command:
+
+```bash
+kglue '철수(은/는)'
+kglue 'K(이/가)'
+kglue '3(을/를)'
+```
+
 ### Framework Integrations
 
 **Django**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
     "tox-uv",
 ]
 
+[project.scripts]
+kglue = "korean_glue.__main__:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/korean_glue/__main__.py
+++ b/src/korean_glue/__main__.py
@@ -1,0 +1,36 @@
+import argparse
+import re
+from .engine import attach
+
+EXAMPLES = [
+    "kglue '철수(은/는)'",
+    "kglue 'K(이/가)'",
+    "kglue '3(을/를)'",
+]
+
+PATTERN = re.compile(r"(.+)\(([^()]+)\)")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="kglue",
+        description="Attach Korean josa",
+    )
+    parser.add_argument("expression", nargs="?", help="WORD(PATTERN)")
+    args = parser.parse_args(argv)
+
+    if not args.expression:
+        parser.print_usage()
+        example_text = "\n".join(f"  {ex}" for ex in EXAMPLES)
+        print("\nExamples:\n" + example_text)
+        return
+
+    match = PATTERN.fullmatch(args.expression)
+    if not match:
+        parser.error("expression must be in WORD(PATTERN) format")
+    word, pattern = match.groups()
+    print(attach(word, pattern))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+
+def run_cli(arg: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "korean_glue", arg],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_cli_basic():
+    assert run_cli("철수(은/는)") == "철수는"
+    assert run_cli("K(이/가)") == "K가"
+    assert run_cli("3(을/를)") == "3을"


### PR DESCRIPTION
## Summary
- provide `kglue` CLI entrypoint to test josa combinations
- document CLI usage in both English and Korean READMEs
- expose script in project metadata
- test CLI behavior

## Testing
- `bash scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_b_6852a083ee7883268245614520c8deda