### PR TITLE
Add PyPI publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
         run: uv pip install hatch
       - name: Build wheel
         run: hatch build -t wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
- publish wheel to PyPI in release workflow

## Testing
- `bash scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_b_6852c2f947f08326a59cff2757b01a17