### PR TITLE
Fix bump-my-version table format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,12 @@ commit = true
 tag = true
 tag_name = "v{new_version}"
 
-[tool.bumpversion.files]
-"pyproject.toml" = "version = \"{current_version}\""
+
+# Paths to update when bumping the project version
+[[tool.bumpversion.files]]
+path = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
 
 [tool.pytest.ini_options]
 addopts = "-ra -q"


### PR DESCRIPTION
## Summary
- correctly define bumpversion files as an array of tables in `pyproject.toml`

## Testing
- `bash scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_b_6852ca6209988326a13b8e99931b307d