### PR TITLE
Add single-josa support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@ Python version.
 - Summarize user-facing changes.
 - CI/CD 자동화 검사가 통과해야 합니다. 로컬에서는 `bash scripts/check.sh`로 확인할 수 있습니다.
 - Ensure all checks pass before submitting.
+- README.md를 수정하면 같은 변경을 한국어 문서 README.ko.md에도 적용하세요.

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [![Python](https://img.shields.io/badge/Python-3.10%20|%203.11%20|%203.12%20|%203.13-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/woojing/korean-glue)](LICENSE)
 
-규칙 기반과 예외 사전을 결합한 현대적인 한국어 조사 처리 파이썬 라이브러리입니다. Django 템플릿 태그와 Jinja2 필터를 제공하여 웹 프레임워크에서도 간편하게 사용할 수 있습니다.
+규칙 기반과 예외 사전을 결합한 현대적인 한국어 조사 처리 파이썬 라이브러리입니다. Django 템플릿 태그와 Jinja2 필터를 제공하여 웹 프레임워크에서도 간편하게 사용할 수 있습니다. `은/는`처럼 두 조사를 함께 주거나 `은`처럼 하나만 줘도 자동으로 올바른 형태를 선택합니다.
 
 ## 설치
 
@@ -25,7 +25,9 @@ pip install korean_glue
 from korean_glue import attach, get_josa
 
 print(get_josa("사과", "은/는"))  # "는"
+print(get_josa("철수", "은"))    # "는"
 print(attach("사과", "은/는"))    # "사과는"
+print(attach("철수", "은"))      # "철수는"
 ```
 
 ### 사용자 정의 예외 규칙
@@ -43,7 +45,7 @@ remove_exception_rule("사과", "은/는")
 패키지를 설치한 뒤 `kglue` 명령어로 간단히 확인할 수 있습니다.
 
 ```bash
-kglue '철수(은/는)'
+kglue '철수(은)'
 kglue 'K(이/가)'
 kglue '3(을/를)'
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python](https://img.shields.io/badge/Python-3.10%20|%203.11%20|%203.12%20|%203.13-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/woojing/korean-glue)](LICENSE)
 
-A modern Python library for Korean josa processing combining rule-based and dictionary-based approaches. Django template tags and Jinja2 filters are included for easy web framework integration.
+A modern Python library for Korean josa processing combining rule-based and dictionary-based approaches. Django template tags and Jinja2 filters are included for easy web framework integration. Patterns can be provided either as pairs like `은/는` or as a single particle such as `은`.
 
 ## Installation
 
@@ -25,7 +25,9 @@ Framework integrations rely on Django and Jinja2.
 from korean_glue import attach, get_josa
 
 print(get_josa("사과", "은/는"))  # "는"
+print(get_josa("철수", "은"))    # "는"
 print(attach("사과", "은/는"))    # "사과는"
+print(attach("철수", "은"))      # "철수는"
 ```
 
 ### Custom Exception Rules
@@ -43,7 +45,7 @@ remove_exception_rule("사과", "은/는")
 Install the package and run the `kglue` command:
 
 ```bash
-kglue '철수(은/는)'
+kglue '철수(은)'
 kglue 'K(이/가)'
 kglue '3(을/를)'
 ```

--- a/src/korean_glue/dictionary.py
+++ b/src/korean_glue/dictionary.py
@@ -2,12 +2,20 @@
 
 from typing import Dict, Tuple, Optional
 
+from .rules import _SINGLE_TO_PAIR
+
 _EXCEPTION_DICT: Dict[Tuple[str, str], str] = {}
 
 
 def lookup_exception(word: str, pattern: str) -> Optional[str]:
     """Return josa from exception dictionary if present."""
-    return _EXCEPTION_DICT.get((word, pattern))
+    result = _EXCEPTION_DICT.get((word, pattern))
+    if result is not None:
+        return result
+    canonical = _SINGLE_TO_PAIR.get(pattern)
+    if canonical is not None:
+        return _EXCEPTION_DICT.get((word, canonical))
+    return None
 
 
 def add_exception_rule(word: str, pattern: str, output: str) -> None:

--- a/src/korean_glue/rules.py
+++ b/src/korean_glue/rules.py
@@ -7,6 +7,21 @@ also be processed in a reasonable way.  Only a subset of rules is implemented
 for demonstration purposes.
 """
 
+# Map single josa to their canonical pairs so that patterns like "은" will
+# behave the same as "은/는".
+_SINGLE_TO_PAIR = {
+    "은": "은/는",
+    "는": "은/는",
+    "이": "이/가",
+    "가": "이/가",
+    "을": "을/를",
+    "를": "을/를",
+    "으로": "으로/로",
+    "로": "으로/로",
+    "아": "아/야",
+    "야": "아/야",
+}
+
 
 def _hangul_has_final(word: str) -> bool:
     """Return True if ``word`` ends with a Hangul syllable that has 받침."""
@@ -55,6 +70,12 @@ def _has_final_l(word: str) -> bool:
 
 def select_josa(word: str, pattern: str) -> str:
     """Select josa according to phonological rules."""
+    # Expand patterns like "은" to "은/는" if possible
+    if "/" not in pattern:
+        canonical = _SINGLE_TO_PAIR.get(pattern)
+        if canonical is None:
+            return pattern
+        pattern = canonical
     parts = pattern.split("/")
     if len(parts) != 2:
         return pattern

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,6 @@ def run_cli(arg: str) -> str:
 
 
 def test_cli_basic():
-    assert run_cli("철수(은/는)") == "철수는"
+    assert run_cli("철수(은)") == "철수는"
     assert run_cli("K(이/가)") == "K가"
     assert run_cli("3(을/를)") == "3을"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,6 +11,8 @@ from korean_glue import (
 def test_basic_josa():
     assert get_josa("사과", "은/는") == "는"
     assert attach("사과", "은/는") == "사과는"
+    assert get_josa("철수", "은") == "는"
+    assert attach("철수", "은") == "철수는"
 
 
 @pytest.mark.parametrize(
@@ -41,5 +43,6 @@ def test_exception_rule():
     add_exception_rule("사과", "은/는", "딱")
     try:
         assert attach("사과", "은/는") == "사과딱"
+        assert attach("사과", "은") == "사과딱"
     finally:
         remove_exception_rule("사과", "은/는")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -23,6 +23,14 @@ def test_jinja_filter_basic():
     assert result == "서울로"
 
 
+def test_jinja_filter_single():
+    env = Environment()
+    jinja_filters.register(env)
+    template = env.from_string("{{ word|josa('은') }}")
+    result = template.render(word="철수")
+    assert result == "철수는"
+
+
 def test_jinja_filter_non_string():
     env = Environment()
     jinja_filters.register(env)
@@ -36,6 +44,13 @@ def test_django_filter_basic():
     template = engine.from_string("{{ word|josa:'이/가' }}")
     result = template.render(Context({"word": "사과"}))
     assert result == "사과가"
+
+
+def test_django_filter_single():
+    engine = Engine(builtins=["korean_glue.integrations.django_tags"])
+    template = engine.from_string("{{ word|josa:'은' }}")
+    result = template.render(Context({"word": "철수"}))
+    assert result == "철수는"
 
 
 def test_django_filter_non_string():


### PR DESCRIPTION
## Summary
- allow particles like `은` to be used without specifying the pair
- keep exception rules working with both single and paired patterns
- document the new usage in both README files
- enforce README synchronization guideline in `AGENTS.md`
- update tests for the new behaviour

## Testing
- `bash scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_b_68538e58b7e48326a519820fba73d80b