### PR TITLE
Add single josa support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@ Python version.
 - Summarize user-facing changes.
 - CI/CD 자동화 검사가 통과해야 합니다. 로컬에서는 `bash scripts/check.sh`로 확인할 수 있습니다.
 - Ensure all checks pass before submitting.
+- If you update `README.md`, also update `README.ko.md` with the same content in Korean.

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,11 +21,15 @@ pip install korean_glue
 
 ### 기본 API
 
+`은`, `이`, `을` 등 한 형태만 지정해도 자동으로 짝이 되는 조사가 선택됩니다.
+
 ```python
 from korean_glue import attach, get_josa
 
 print(get_josa("사과", "은/는"))  # "는"
 print(attach("사과", "은/는"))    # "사과는"
+print(get_josa("철수", "은"))    # "는"
+print(attach("철수", "은"))      # "철수는"
 ```
 
 ### 사용자 정의 예외 규칙
@@ -44,6 +48,7 @@ remove_exception_rule("사과", "은/는")
 
 ```bash
 kglue '철수(은/는)'
+kglue '철수(은)'
 kglue 'K(이/가)'
 kglue '3(을/를)'
 ```

--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ Framework integrations rely on Django and Jinja2.
 
 ### Basic API
 
+Single-form patterns like `은`, `이`, or `을` are also recognized and
+automatically expanded to their counterparts.
+
 ```python
 from korean_glue import attach, get_josa
 
 print(get_josa("사과", "은/는"))  # "는"
 print(attach("사과", "은/는"))    # "사과는"
+print(get_josa("철수", "은"))    # "는"
+print(attach("철수", "은"))      # "철수는"
 ```
 
 ### Custom Exception Rules
@@ -44,6 +49,7 @@ Install the package and run the `kglue` command:
 
 ```bash
 kglue '철수(은/는)'
+kglue '철수(은)'
 kglue 'K(이/가)'
 kglue '3(을/를)'
 ```

--- a/src/korean_glue/rules.py
+++ b/src/korean_glue/rules.py
@@ -7,6 +7,33 @@ also be processed in a reasonable way.  Only a subset of rules is implemented
 for demonstration purposes.
 """
 
+# Mapping of single josa forms to their canonical pair pattern.  This allows
+# passing only one side of a pair (e.g. ``"은"``) to the engine which will then
+# determine the correct counterpart automatically.
+_ALIAS_TO_PATTERN = {
+    "은": "은/는",
+    "는": "은/는",
+    "이": "이/가",
+    "가": "이/가",
+    "을": "을/를",
+    "를": "을/를",
+    "과": "과/와",
+    "와": "과/와",
+    "으로": "으로/로",
+    "로": "으로/로",
+    "아": "아/야",
+    "야": "아/야",
+    "이나": "이나/나",
+    "나": "이나/나",
+    "이랑": "이랑/랑",
+    "랑": "이랑/랑",
+}
+
+
+def _canonicalize_pattern(pattern: str) -> str:
+    """Return the canonical josa pattern for ``pattern``."""
+    return _ALIAS_TO_PATTERN.get(pattern, pattern)
+
 
 def _hangul_has_final(word: str) -> bool:
     """Return True if ``word`` ends with a Hangul syllable that has 받침."""
@@ -55,6 +82,7 @@ def _has_final_l(word: str) -> bool:
 
 def select_josa(word: str, pattern: str) -> str:
     """Select josa according to phonological rules."""
+    pattern = _canonicalize_pattern(pattern)
     parts = pattern.split("/")
     if len(parts) != 2:
         return pattern

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,5 +14,6 @@ def run_cli(arg: str) -> str:
 
 def test_cli_basic():
     assert run_cli("철수(은/는)") == "철수는"
+    assert run_cli("철수(은)") == "철수는"
     assert run_cli("K(이/가)") == "K가"
     assert run_cli("3(을/를)") == "3을"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,6 +11,8 @@ from korean_glue import (
 def test_basic_josa():
     assert get_josa("사과", "은/는") == "는"
     assert attach("사과", "은/는") == "사과는"
+    assert get_josa("철수", "은") == "는"
+    assert attach("철수", "은") == "철수는"
 
 
 @pytest.mark.parametrize(
@@ -29,6 +31,9 @@ def test_basic_josa():
         ("M", "은/는", "M은"),
         ("K", "이/가", "K가"),
         ("L", "으로/로", "L로"),
+        ("사과", "은", "사과는"),
+        ("학생", "가", "학생이"),
+        ("서울", "로", "서울로"),
         ("프로젝트", "은/는", "프로젝트는"),
         ("나에게", "만", "나에게만"),
     ],


### PR DESCRIPTION
## Summary
- support single-form particles like `은`/`는` etc.
- document usage in both README files
- enforce updating README.ko.md when README.md changes
- extend CLI and library tests for new behaviour

## Testing
- `bash scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_b_68538e58b7e48326a519820fba73d80b