### PR TITLE
Add josa_text filter for block processing

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -78,6 +78,15 @@ jinja_filters.register(env)
 result = env.from_string("{{ word|josa('으로/로') }}").render(word="서울")
 ```
 
+`josa_text` 필터를 사용하면 여러 개의 ``단어(조사)`` 형식을 한 번에 처리할 수 있습니다.
+
+```django
+{% load korean_glue.integrations.django_tags %}
+{% filter josa_text %}
+{{ person }}(은) {{ item }}(을/를) 샀다
+{% endfilter %}
+```
+
 ## 테스트 실행
 
 개발 환경을 준비한 뒤 다음 명령어로 테스트를 실행합니다(자세한 내용은 `CONTRIBUTING.md` 참고).
@@ -85,3 +94,4 @@ result = env.from_string("{{ word|josa('으로/로') }}").render(word="서울")
 ```bash
 pytest
 ```
+

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ jinja_filters.register(env)
 result = env.from_string("{{ word|josa('으로/로') }}").render(word="서울")
 ```
 
+Use the `josa_text` filter to process a block containing multiple
+``WORD(PATTERN)`` placeholders at once:
+
+```django
+{% load korean_glue.integrations.django_tags %}
+{% filter josa_text %}
+{{ person }}(은) {{ item }}(을/를) 샀다
+{% endfilter %}
+```
+
 ## Running Tests
 
 After setting up a development environment (see `CONTRIBUTING.md`), run:

--- a/src/korean_glue/__init__.py
+++ b/src/korean_glue/__init__.py
@@ -1,6 +1,6 @@
 """Public API for korean_glue."""
 
-from .engine import attach, get_josa
+from .engine import attach, get_josa, auto_attach
 from .dictionary import (
     add_exception_rule,
     remove_exception_rule,
@@ -12,6 +12,7 @@ from .exceptions import JosaError, DictionaryError
 __all__ = [
     "attach",
     "get_josa",
+    "auto_attach",
     "add_exception_rule",
     "remove_exception_rule",
     "load_user_dictionary",

--- a/src/korean_glue/engine.py
+++ b/src/korean_glue/engine.py
@@ -2,6 +2,9 @@
 
 from .rules import select_josa
 from .dictionary import lookup_exception
+import re
+
+_BLOCK_RE = re.compile(r"([^\s()]+)\(([^()]+)\)")
 
 
 def attach(word: str, pattern: str) -> str:
@@ -16,3 +19,13 @@ def get_josa(word: str, pattern: str) -> str:
     if josa is not None:
         return josa
     return select_josa(word, pattern)
+
+
+def auto_attach(text: str) -> str:
+    """Replace ``WORD(PATTERN)`` placeholders in ``text`` with attached josa."""
+
+    def repl(match: re.Match) -> str:
+        word, pattern = match.groups()
+        return attach(word, pattern)
+
+    return _BLOCK_RE.sub(repl, text)

--- a/src/korean_glue/integrations/django_tags.py
+++ b/src/korean_glue/integrations/django_tags.py
@@ -1,8 +1,8 @@
 """Django template filters for korean_glue."""
 
-from django import template
+from django import template  # type: ignore
 
-from ..engine import attach
+from ..engine import attach, auto_attach
 
 register = template.Library()
 
@@ -12,3 +12,10 @@ def josa_filter(word, pattern):
     if not isinstance(word, str):
         return word
     return attach(word, pattern)
+
+
+@register.filter(name="josa_text")
+def josa_text_filter(text):
+    if not isinstance(text, str):
+        return text
+    return auto_attach(text)

--- a/src/korean_glue/integrations/jinja_filters.py
+++ b/src/korean_glue/integrations/jinja_filters.py
@@ -2,7 +2,7 @@
 
 from jinja2 import Environment
 
-from ..engine import attach
+from ..engine import attach, auto_attach
 
 
 def josa_filter(word, pattern):
@@ -11,5 +11,12 @@ def josa_filter(word, pattern):
     return attach(word, pattern)
 
 
+def josa_text_filter(text):
+    if not isinstance(text, str):
+        return text
+    return auto_attach(text)
+
+
 def register(env: Environment) -> None:
     env.filters["josa"] = josa_filter
+    env.filters["josa_text"] = josa_text_filter

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -31,6 +31,16 @@ def test_jinja_filter_non_string():
     assert result == "10"
 
 
+def test_jinja_text_block():
+    env = Environment()
+    jinja_filters.register(env)
+    template = env.from_string(
+        "{% filter josa_text %}철수(은) {{ place }}(을/를) 좋아한다{% endfilter %}"
+    )
+    result = template.render(place="사과")
+    assert result == "철수는 사과를 좋아한다"
+
+
 def test_django_filter_basic():
     engine = Engine(builtins=["korean_glue.integrations.django_tags"])
     template = engine.from_string("{{ word|josa:'이/가' }}")
@@ -43,3 +53,13 @@ def test_django_filter_non_string():
     template = engine.from_string("{{ value|josa:'을/를' }}")
     result = template.render(Context({"value": 10}))
     assert result == "10"
+
+
+def test_django_text_block():
+    engine = Engine(builtins=["korean_glue.integrations.django_tags"])
+    template = engine.from_string(
+        "{% filter josa_text %}{{ person }}(은) {{ item }}(을/를) 샀다{% endfilter %}"
+    )
+    ctx = Context({"person": "민수", "item": "책"})
+    result = template.render(ctx)
+    assert result == "민수는 책을 샀다"


### PR DESCRIPTION
## Summary
- support auto josa replacement for multiple placeholders
- expose `auto_attach` API
- add `josa_text` filters for Jinja and Django
- document new block filter usage
- test block level josa processing

## Testing
- `pre-commit run --files src/korean_glue/engine.py src/korean_glue/__init__.py src/korean_glue/integrations/jinja_filters.py src/korean_glue/integrations/django_tags.py tests/test_integrations.py README.md README.ko.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871b8854efc83268e4923db914f4467